### PR TITLE
Change the card shuffling feature

### DIFF
--- a/Assets/Scripts/Table.cs
+++ b/Assets/Scripts/Table.cs
@@ -151,7 +151,9 @@ public class Table : MonoBehaviourPun
     public void ShuffleDeck()
     {
         Debug.Log("Shuffling Deck");
-        deck = deck.OrderBy(Matrix4x4 => UnityEngine.Random.value).ToList(); //poor complexity but with only 100 items it *should* be okay
+        //deck = deck.OrderBy(Matrix4x4 => UnityEngine.Random.value).ToList(); //poor complexity but with only 100 items it *should* be okay
+        // Use LINQ algorithm to shuffle a deck 
+        deck = deck.OrderBy(i => Guid.NewGuid()).ToList();
     }
 
     public void InstantiateDeckToPhoton()


### PR DESCRIPTION
closes #17 
Use LINQ algorithm to shuffle a deck

In the TABLE class(\Assets\Scripts\table.cs), I commented out the old shuffling feature in line 154 and added the new shuffling feature in line 156.

Acceptance Criteria:
the deck get initiated in the following order ( 8 Blitz, 4 fumble, 8 fiveYardRun, 8 firstDown, 8 passCompletion, 8 endOfQuarter, 11 blockedKick, 4 tackle, 3 interception, 7 fieldGoal, 6 conversion, 2 hailMary, 6 passingTD, 6 rushingTD and 11 extraPoint) 

when the computer draws a hand for a player it must not be in that order.