### PR TITLE
Fixing First Down card

### DIFF
--- a/Assets/Scripts/Cards and Deck/ContinuationCards/PassCompletion.cs
+++ b/Assets/Scripts/Cards and Deck/ContinuationCards/PassCompletion.cs
@@ -18,17 +18,14 @@ public class PassCompletion : Card
 
     public new void Play()
     {
-
-    }
-
-    // Start is called before the first frame update
-    void Start()
-    {
-    }
-
-    // Update is called once per frame
-    void Update()
-    {
-        
+        if (Table.myGamePlayer.myTurn)
+        {
+            if (Table.myGamePlayer.table.homeLastPlayed.transform.childCount > 0)
+            {
+                Table.myGamePlayer.table.homeLastPlayed.transform.GetChild(0).transform.SetParent(Table.myGamePlayer.table.homePlayedCards.transform);
+            }
+            this.transform.SetParent(Table.myGamePlayer.table.homeLastPlayed.transform);
+            Table.myGamePlayer.table.DrawCard(2);
+        }
     }
 }

--- a/Assets/Scripts/Table.cs
+++ b/Assets/Scripts/Table.cs
@@ -172,6 +172,18 @@ public class Table : MonoBehaviourPun
         GameObject.FindWithTag("DeckObject").GetComponent<Deck>().deckIndex++;
     }
 
+    public void DrawCard(int number) // to be used with the Continuation Cards
+    {
+        for (int i = 0; i < number; i++)
+        {
+            Debug.Log("Drawing card now");
+            int nextCardToDraw = GameObject.FindWithTag("DeckObject").GetComponent<Deck>().deckIndex;
+            Debug.Log("Cards in deck " + GameObject.FindWithTag("DeckObject").transform.childCount);
+            myGamePlayer.AddCard(GameObject.FindWithTag("DeckObject").transform.GetChild(nextCardToDraw).gameObject);
+            GameObject.FindWithTag("DeckObject").GetComponent<Deck>().deckIndex++;
+        }
+    }
+
     public void Deal()
     {
         Debug.Log("Dealing Cards");


### PR DESCRIPTION
Close #9 
First Down card provides draw 2 cards for the user and add them to the player hand.

Acceptance Criteria:
When a player plays the First Down card the computer should provide the user with 2 additional cards from the deck.

NOTE:
I had to re-write DrawCard that takes an argument in Table.cs (issue #10 ) since it wasn't merged to main before I started on this task.
